### PR TITLE
Distill is a journal, not a blog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -794,6 +794,14 @@ Books
 
 
 ************
+Journals
+************
+
+* **Distill journal**:
+  [`Link <https://distill.pub/>`_]
+
+
+************
 Blogs
 ************
 
@@ -810,9 +818,6 @@ Blogs
 
 * **WILDML**:
   [`Link <http://www.wildml.com/about/>`_]
-
-* **Distill blog**:
-  [`Link <https://distill.pub/>`_]
 
 * **BAIR** Berkeley Artificial Inteliigent Research:
   [`Link <http://bair.berkeley.edu/blog/>`_]


### PR DESCRIPTION
https://distill.pub has peer review process and that is what makes it different from the blogs. I suggest starting a new category for journals and putting Distill there. I think it would be appropriate to the effort and results Distill achieved in promoting clear, well-documented and human-understandable research in machine learning.